### PR TITLE
Support spaces in paths using URL pattern

### DIFF
--- a/src/awesome/console/AwesomeLinkFilter.java
+++ b/src/awesome/console/AwesomeLinkFilter.java
@@ -29,7 +29,7 @@ public class AwesomeLinkFilter implements Filter {
 			"(?:(?::|, line |\\()(?<row>\\d+)(?:[:,](?<col>\\d+)\\)?)?)?)"
 	);
 	private static final Pattern URL_PATTERN = Pattern.compile(
-			"(?<link>(?<protocol>(([a-zA-Z]+):)?(/|\\\\|~))(?<path>[-_.!~*\\\\'()a-zA-Z0-9;/?:@&=+$,%#]+))"
+			"(?<link>(?<protocol>(([a-zA-Z]+):)?(/|\\\\|~))(?<path>[-_.!~*\\\\'()a-zA-Z0-9;/?:@&=+$,%# ]+))"
 	);
 	private static final int maxSearchDepth = 1;
 


### PR DESCRIPTION
This allows matching of Windows-style directories in console output.

E.g, with Console Output:
`Opening Directory <D:\Folder\SubFolder WithSpaces\Test>`

Currently, two separate matches are highlighted:
1. `D:\Folder\SubFolder`
2. `WithSpaces\Test`