### PR TITLE
Fixed regex for properly recognizing full windows path

### DIFF
--- a/src/awesome/console/AwesomeLinkFilter.java
+++ b/src/awesome/console/AwesomeLinkFilter.java
@@ -25,7 +25,7 @@ import java.util.regex.Pattern;
 
 public class AwesomeLinkFilter implements Filter {
 	private static final Pattern FILE_PATTERN = Pattern.compile(
-			"(?<link>(?<path>(\\.|~)?(?:[a-zA-Z]:\\\\|/)?[a-zA-Z0-9_][a-zA-Z0-9/\\-_.\\\\]*\\.[a-zA-Z0-9\\-_.]+)" +
+			"(?<link>(?<path>(\\.|~)?(?:[a-zA-Z]:)?(/|\\\\)*[a-zA-Z0-9_][a-zA-Z0-9/\\-_.\\\\]*\\.[a-zA-Z0-9\\-_.]+)" +
 			"(?:(?::|, line |\\()(?<row>\\d+)(?:[:,](?<col>\\d+)\\)?)?)?)"
 	);
 	private static final Pattern URL_PATTERN = Pattern.compile(


### PR DESCRIPTION
Hi @anthraxx,
There are one additional fix which would be nice if You could include.
Currently it seems that there are issue with regexp for recognizing windows paths which includes drive, like: `C:\\test.txt`. As I understand than current part of regexp is invalid:
`(?:[a-zA-Z]:\\\\|/)` and it would translate as `:[a-zA-Z]:\\\\` or `/`.

And additional thing, I added `*` after first directory seperator, because `//////` are still valid path. If You try `cd ///////` it would work properly. 