### PR TITLE
Fix: add windows support for tslint path format

### DIFF
--- a/src/awesome/console/AwesomeLinkFilter.java
+++ b/src/awesome/console/AwesomeLinkFilter.java
@@ -25,7 +25,7 @@ import java.util.regex.Pattern;
 
 public class AwesomeLinkFilter implements Filter {
 	private static final Pattern FILE_PATTERN = Pattern.compile(
-			"(?<link>(?<path>([.~])?(?:[a-zA-Z]:\\\\|/)?\\w[\\w/\\-.\\\\]*\\.[\\w\\-.]+)\\$?" +
+			"(?<link>(?<path>([.~])?(?:[a-zA-Z]:(\\\\|/))?\\w[\\w/\\-.\\\\]*\\.[\\w\\-.]+)\\$?" +
 			"(?:(?::|, line |\\()(?<row>\\d+)(?:[:,]( column )?(?<col>\\d+)\\)?)?)?)",
 			Pattern.UNICODE_CHARACTER_CLASS);
 	private static final Pattern URL_PATTERN = Pattern.compile(

--- a/test/awesome/console/AwesomeLinkFilterTest.java
+++ b/test/awesome/console/AwesomeLinkFilterTest.java
@@ -172,6 +172,11 @@ public class AwesomeLinkFilterTest extends CodeInsightFixtureTestCase {
 		assertURLDetection("something (C:\\root\\something.java) blabla", "C:\\root\\something.java");
 	}
 
+	@Test
+	public void testWindowsDirectoryBackwardSlashes() {
+		assertPathDetection("C:/Windows/Temp/test.tsx:5:3", "C:/Windows/Temp/test.tsx", 5, 3);
+	}
+
 	private void assertPathDetection(final String line, final String expected) {
 		assertPathDetection(line, expected, -1, -1);
 	}

--- a/test/awesome/console/IntegrationTest.java
+++ b/test/awesome/console/IntegrationTest.java
@@ -32,6 +32,7 @@ public class IntegrationTest {
 		System.out.println("something (file1.java) blabla");
 		System.out.println("(file:///tmp)");
 		System.out.println("C:/Windows/Temp,");
+		System.out.println("C:/Windows/Temp/test.tsx:5:3");
 		System.out.println("Just a file: test/awesome/integration/file1.java, line 2, column 2");
 		System.out.println("Just a file with path: file://integration/file1.java:5:4");
 		System.out.println("Just a file with path: C:\\integration\\file1.java:5:4");


### PR DESCRIPTION
closes: https://github.com/anthraxx/intellij-awesome-console/issues/52

Tested with:
```
ERROR: C:/Users/ControlsSidebar.tsx:216:17 - Calls to 'console' are not allowed.
```

Result:
```
match: C:/Users/ControlsSidebar.tsx:216:17
row: 216
col: 17
path: C:/Users/ControlsSidebar.tsx
```

@anthraxx mention for attention