### PR TITLE
Add support for C# stacktrace line numbers

### DIFF
--- a/src/main/java/awesome/console/AwesomeLinkFilter.java
+++ b/src/main/java/awesome/console/AwesomeLinkFilter.java
@@ -30,7 +30,7 @@ public class AwesomeLinkFilter implements Filter {
 
 	public static final Pattern FILE_PATTERN = Pattern.compile(
 			"(?<link>(?<path>\"?([.~])?(([a-zA-Z]:)?[\\\\/])?\\w[@\\w/\\-.\\\\]*\\.[\\w\\-.]+)\\$?" +
-			"(?:(?::|\"?, line |:\\[|\\()(?<row>\\d+)(?:[:,]( column )?(?<col>\\d+)([)\\]])?)?)?)",
+			"(?:(?::|\"?, line |:line |:\\[|\\()(?<row>\\d+)(?:[:,]( column )?(?<col>\\d+)([)\\]])?)?)?)",
 			Pattern.UNICODE_CHARACTER_CLASS);
 	public static final Pattern URL_PATTERN = Pattern.compile(
 			"(?<link>[(']?(?<protocol>(([a-zA-Z]+):)?([/\\\\~]))(?<path>[-.!~*\\\\'()\\w;/?:@&=+$,%#]+))",

--- a/src/test/java/awesome/console/AwesomeLinkFilterTest.java
+++ b/src/test/java/awesome/console/AwesomeLinkFilterTest.java
@@ -196,6 +196,11 @@ public class AwesomeLinkFilterTest extends BasePlatformTestCase {
 	}
 
 	@Test
+	public void testCSharpStacktraceFormat() {
+		assertPathDetection("C:/some/very/weird/path/test.cs:line 456", "C:/some/very/weird/path/test.cs:line 456", 456);
+	}
+
+	@Test
 	public void testPythonTracebackWithQuotes() {
 		assertPathDetection("File \"/Applications/plugins/python-ce/helpers/pycharm/teamcity/diff_tools.py\", line 38", "\"/Applications/plugins/python-ce/helpers/pycharm/teamcity/diff_tools.py\", line 38",38);
 	}


### PR DESCRIPTION
Currently the file references in C# stacktraces are not properly parsing the line number. This PR rectifies that.